### PR TITLE
DWH-2595: spark distrs removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,7 @@ RUN  apt-get update \
   libffi-dev
 ADD http://d3kbcqa49mib13.cloudfront.net/spark-1.6.1-bin-hadoop2.6.tgz /opt/
 RUN cd /opt/ && tar -xvf ./spark-1.6.1-bin-hadoop2.6.tgz
+RUN rm -rf /opt/spark-1.6.1-bin-hadoop2.6.tgz
 ADD https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.6.tgz /opt/
 RUN cd /opt/ && tar -xvf ./spark-2.3.0-bin-hadoop2.6.tgz
+RUN rm -rf /opt/spark-2.3.0-bin-hadoop2.6.tgz


### PR DESCRIPTION
Image volume footprint optimised.
Spark & spark2 distributivevs removed after unarchive. 