### PR TITLE
Container size optimized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,11 @@ RUN  apt-get update \
   libffi-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-ADD http://d3kbcqa49mib13.cloudfront.net/spark-1.6.1-bin-hadoop2.6.tgz /opt/
-RUN cd /opt/ && tar -xvf ./spark-1.6.1-bin-hadoop2.6.tgz \
+RUN cd /opt/ \
+  && wget http://d3kbcqa49mib13.cloudfront.net/spark-1.6.1-bin-hadoop2.6.tgz \
+  && tar -xvf ./spark-1.6.1-bin-hadoop2.6.tgz \
   && rm -rf /opt/spark-1.6.1-bin-hadoop2.6.tgz
-ADD https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.6.tgz /opt/
-RUN cd /opt/ && tar -xvf ./spark-2.3.0-bin-hadoop2.6.tgz \
+RUN cd /opt/ \
+  && wget https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.6.tgz \
+  && tar -xvf ./spark-2.3.0-bin-hadoop2.6.tgz \
   && rm -rf /opt/spark-2.3.0-bin-hadoop2.6.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,12 @@ RUN  apt-get update \
   libpq-dev \
   build-essential \
   libssl-dev \
-  libffi-dev
+  libffi-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 ADD http://d3kbcqa49mib13.cloudfront.net/spark-1.6.1-bin-hadoop2.6.tgz /opt/
-RUN cd /opt/ && tar -xvf ./spark-1.6.1-bin-hadoop2.6.tgz
-RUN rm -rf /opt/spark-1.6.1-bin-hadoop2.6.tgz
+RUN cd /opt/ && tar -xvf ./spark-1.6.1-bin-hadoop2.6.tgz \
+  && rm -rf /opt/spark-1.6.1-bin-hadoop2.6.tgz
 ADD https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.6.tgz /opt/
-RUN cd /opt/ && tar -xvf ./spark-2.3.0-bin-hadoop2.6.tgz
-RUN rm -rf /opt/spark-2.3.0-bin-hadoop2.6.tgz
+RUN cd /opt/ && tar -xvf ./spark-2.3.0-bin-hadoop2.6.tgz \
+  && rm -rf /opt/spark-2.3.0-bin-hadoop2.6.tgz


### PR DESCRIPTION
During the reading The DevOps 2.0 Toolkit by Viktor Farcic I've just realized why this image hadn't shrunk even after deleting Spark archives.
Each `RUN` sections in Dockerfile introduces immutable image layer, to delete archive it should be done in the same section as unzipping.