### PR TITLE
Downgrade version of rsa used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ RUN pip install cffi \
         elasticsearch \
         netaddr \
         hvac \
-        ansible==2.8.2
+        ansible==2.8.2 \
+        rsa==4.0
 
 # install vault
 RUN wget -P /tmp/vault https://releases.hashicorp.com/vault/1.1.3/vault_1.1.3_linux_amd64.zip \


### PR DESCRIPTION
Version >4.1 of the rsa library are no longer compatible with Python2, 
therefore until we migrate it we will have to use the last retrocompatible 
version, the 4.0